### PR TITLE
[codex] Add serde JSON convenience APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,25 @@ cargo run --example repair_and_parse
 
 | Feature | Default | Notes |
 | --- | --- | --- |
-| `serde` | No | Enables optional `serde` and `serde_json` dependencies. The public API remains string-based. |
+| `serde` | No | Enables optional `serde` and `serde_json` dependencies plus repair-and-parse helpers. |
 
 For most applications, add `serde_json` directly to your own `Cargo.toml` if you
 want to parse the repaired string into typed data.
+
+With the `serde` feature enabled, the crate also provides convenience helpers
+for repair-and-parse workflows:
+
+```rust
+use jsonrepair_rs::jsonrepair_value;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let value = jsonrepair_value("{name: 'Ada', active: True}")?;
+
+    assert_eq!(value["name"], "Ada");
+    assert_eq!(value["active"], true);
+    Ok(())
+}
+```
 
 ## Development
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,6 +91,7 @@ impl std::error::Error for JsonRepairError {}
 /// Error returned by serde-powered repair-and-parse helpers.
 #[cfg(feature = "serde")]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum JsonRepairParseError {
     /// The input could not be repaired safely.
     Repair(JsonRepairError),

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,3 +87,47 @@ impl fmt::Display for JsonRepairError {
 }
 
 impl std::error::Error for JsonRepairError {}
+
+/// Error returned by serde-powered repair-and-parse helpers.
+#[cfg(feature = "serde")]
+#[derive(Debug)]
+pub enum JsonRepairParseError {
+    /// The input could not be repaired safely.
+    Repair(JsonRepairError),
+    /// The repaired output could not be parsed as JSON.
+    Parse(serde_json::Error),
+}
+
+#[cfg(feature = "serde")]
+impl fmt::Display for JsonRepairParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Repair(err) => err.fmt(f),
+            Self::Parse(err) => write!(f, "failed to parse repaired JSON: {err}"),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl std::error::Error for JsonRepairParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Repair(err) => Some(err),
+            Self::Parse(err) => Some(err),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl From<JsonRepairError> for JsonRepairParseError {
+    fn from(err: JsonRepairError) -> Self {
+        Self::Repair(err)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl From<serde_json::Error> for JsonRepairParseError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Parse(err)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ mod chars;
 mod error;
 mod parser;
 
+#[cfg(feature = "serde")]
+pub use error::JsonRepairParseError;
 pub use error::{JsonRepairError, JsonRepairErrorKind};
 
 /// Repair a broken JSON string, returning valid JSON.
@@ -52,4 +54,24 @@ pub use error::{JsonRepairError, JsonRepairErrorKind};
 pub fn jsonrepair(input: &str) -> Result<String, JsonRepairError> {
     let repairer = parser::JsonRepairer::new(input);
     repairer.repair()
+}
+
+/// Repair a broken JSON string and parse it into [`serde_json::Value`].
+///
+/// This helper is available with the `serde` feature.
+#[cfg(feature = "serde")]
+pub fn jsonrepair_value(input: &str) -> Result<serde_json::Value, JsonRepairParseError> {
+    jsonrepair_parse(input)
+}
+
+/// Repair a broken JSON string and deserialize it into the requested type.
+///
+/// This helper is available with the `serde` feature.
+#[cfg(feature = "serde")]
+pub fn jsonrepair_parse<T>(input: &str) -> Result<T, JsonRepairParseError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let repaired = jsonrepair(input)?;
+    serde_json::from_str(&repaired).map_err(JsonRepairParseError::from)
 }

--- a/tests/serde_tests.rs
+++ b/tests/serde_tests.rs
@@ -1,0 +1,38 @@
+#![cfg(feature = "serde")]
+
+use jsonrepair_rs::{jsonrepair_parse, jsonrepair_value, JsonRepairParseError};
+
+#[test]
+fn repairs_and_returns_value() {
+    let value = jsonrepair_value("{name: 'Ada', active: True, attempts: [1,2,],}").unwrap();
+
+    assert_eq!(value["name"], "Ada");
+    assert_eq!(value["active"], true);
+    assert_eq!(value["attempts"][1], 2);
+}
+
+#[derive(Debug, serde::Deserialize, PartialEq)]
+struct User {
+    name: String,
+    active: bool,
+}
+
+#[test]
+fn repairs_and_deserializes_target_type() {
+    let user: User = jsonrepair_parse("{name: 'Ada', active: True}").unwrap();
+
+    assert_eq!(
+        user,
+        User {
+            name: "Ada".to_string(),
+            active: true,
+        }
+    );
+}
+
+#[test]
+fn preserves_repair_errors() {
+    let err = jsonrepair_value(r#""\u00""#).unwrap_err();
+
+    assert!(matches!(err, JsonRepairParseError::Repair(_)));
+}


### PR DESCRIPTION
## Summary

- add `jsonrepair_value` and `jsonrepair_parse<T>` behind the `serde` feature
- add `JsonRepairParseError` to distinguish repair failures from parse failures
- document the repair-and-parse workflow and cover it with feature-gated tests

Closes #4

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-targets`
- `cargo test --features serde --all-targets`