### PR TITLE
[codex] Add writer repair output API

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,12 @@ pub fn jsonrepair(input: &str) -> Result<String, JsonRepairError>
 Exports:
 
 - `jsonrepair` repairs one input string.
+- `jsonrepair_to_writer` repairs one input string and writes the result to any
+  `std::io::Write`.
 - `JsonRepairError` contains `message`, `position`, `kind`, `line`, and `column`.
 - `JsonRepairErrorKind` is a non-exhaustive enum for programmatic error handling.
+- `JsonRepairWriteError` distinguishes repair failures from output write
+  failures in writer-based workflows.
 
 The output is valid JSON when the function returns `Ok(...)`. When the input
 cannot be repaired safely, the function returns an error instead of guessing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub use error::{JsonRepairError, JsonRepairErrorKind};
 
 /// Error returned by writer-based repair helpers.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum JsonRepairWriteError {
     /// The input could not be repaired safely.
     Repair(JsonRepairError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,58 @@ mod parser;
 
 pub use error::{JsonRepairError, JsonRepairErrorKind};
 
+/// Error returned by writer-based repair helpers.
+#[derive(Debug)]
+pub enum JsonRepairWriteError {
+    /// The input could not be repaired safely.
+    Repair(JsonRepairError),
+    /// The repaired JSON could not be written to the destination.
+    Write(std::io::Error),
+}
+
+impl std::fmt::Display for JsonRepairWriteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Repair(err) => err.fmt(f),
+            Self::Write(err) => write!(f, "failed to write repaired JSON: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for JsonRepairWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Repair(err) => Some(err),
+            Self::Write(err) => Some(err),
+        }
+    }
+}
+
+impl From<JsonRepairError> for JsonRepairWriteError {
+    fn from(err: JsonRepairError) -> Self {
+        Self::Repair(err)
+    }
+}
+
+impl From<std::io::Error> for JsonRepairWriteError {
+    fn from(err: std::io::Error) -> Self {
+        Self::Write(err)
+    }
+}
+
+/// Repair a broken JSON string and write the valid JSON to a writer.
+///
+/// This is a writer convenience API. It repairs the input first, then writes
+/// the repaired JSON bytes to the provided [`std::io::Write`] destination.
+pub fn jsonrepair_to_writer<W>(input: &str, writer: &mut W) -> Result<(), JsonRepairWriteError>
+where
+    W: std::io::Write + ?Sized,
+{
+    let repaired = jsonrepair(input)?;
+    writer.write_all(repaired.as_bytes())?;
+    Ok(())
+}
+
 /// Repair a broken JSON string, returning valid JSON.
 ///
 /// Handles 30+ categories of issues including:

--- a/tests/writer_tests.rs
+++ b/tests/writer_tests.rs
@@ -1,0 +1,44 @@
+use std::io::{self, Write};
+
+use jsonrepair_rs::{jsonrepair_to_writer, JsonRepairWriteError};
+
+#[test]
+fn repairs_into_writer() {
+    let mut output = Vec::new();
+
+    jsonrepair_to_writer("{name: 'Ada', active: True}", &mut output).unwrap();
+
+    assert_eq!(
+        String::from_utf8(output).unwrap(),
+        r#"{"name": "Ada", "active": true}"#
+    );
+}
+
+#[test]
+fn preserves_repair_errors() {
+    let mut output = Vec::new();
+    let err = jsonrepair_to_writer(r#""\u00""#, &mut output).unwrap_err();
+
+    assert!(matches!(err, JsonRepairWriteError::Repair(_)));
+    assert!(output.is_empty());
+}
+
+struct FailingWriter;
+
+impl Write for FailingWriter {
+    fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+        Err(io::Error::new(io::ErrorKind::Other, "destination closed"))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn reports_writer_errors() {
+    let mut output = FailingWriter;
+    let err = jsonrepair_to_writer("{name: 'Ada'}", &mut output).unwrap_err();
+
+    assert!(matches!(err, JsonRepairWriteError::Write(_)));
+}


### PR DESCRIPTION
## Summary

- add `jsonrepair_to_writer` for writing repaired JSON directly into `std::io::Write` destinations
- add `JsonRepairWriteError` so callers can distinguish repair errors from write errors
- document the new export and cover success, repair failure, and writer failure paths

Closes #3

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-targets`