### PR TITLE
[codex] Add jsonrepair CLI binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ LLMs, copied from JavaScript/Python/MongoDB contexts, pasted from markdown, or
 truncated in transit. It is a Rust port inspired by
 [josdejong/jsonrepair](https://github.com/josdejong/jsonrepair).
 
-This crate currently provides a library API only. It does not ship a CLI binary.
+This crate provides both a library API and a small command-line binary.
 
 ## Installation
 
@@ -30,6 +30,26 @@ jsonrepair-rs = "0.1.1"
 ```
 
 Minimum supported Rust version: 1.70.
+
+## Command Line
+
+Install the binary with Cargo:
+
+```bash
+cargo install jsonrepair-rs
+```
+
+Repair stdin to stdout:
+
+```bash
+printf "{name: 'Ada', active: True}" | jsonrepair
+```
+
+Repair a file and write the result to another file:
+
+```bash
+jsonrepair broken.json --output repaired.json
+```
 
 ## Quick Start
 
@@ -141,7 +161,7 @@ them outside this crate.
 - Maximum supported nesting depth is 512.
 - The crate preserves much of the original whitespace where possible.
 - It returns a repaired JSON string, not a `serde_json::Value`.
-- It does not provide streaming repair or a command-line binary.
+- It does not provide streaming repair.
 - It is designed for practical repair, not for accepting arbitrary unsafe input
   as if it were trustworthy. Validate the repaired data according to your
   application's schema before using it.

--- a/src/bin/jsonrepair.rs
+++ b/src/bin/jsonrepair.rs
@@ -1,0 +1,172 @@
+use std::{
+    env,
+    ffi::{OsStr, OsString},
+    fmt, fs,
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
+    process,
+};
+
+use jsonrepair_rs::{jsonrepair, JsonRepairError};
+
+const HELP: &str = "\
+Repair malformed JSON-like text into valid JSON.
+
+Usage:
+  jsonrepair [OPTIONS] [INPUT_FILE]
+
+Arguments:
+  INPUT_FILE          Read input from this file. Reads stdin when omitted or '-'.
+
+Options:
+  -o, --output PATH   Write repaired JSON to PATH instead of stdout.
+  -h, --help          Print help.
+  -V, --version       Print version.
+";
+
+fn main() {
+    match run() {
+        Ok(()) => {}
+        Err(CliError::Usage(message)) => {
+            eprintln!("jsonrepair: {message}");
+            eprintln!("Try 'jsonrepair --help' for usage.");
+            process::exit(2);
+        }
+        Err(err) => {
+            eprintln!("jsonrepair: {err}");
+            process::exit(1);
+        }
+    }
+}
+
+fn run() -> Result<(), CliError> {
+    let args = Args::parse(env::args_os().skip(1))?;
+
+    if args.help {
+        print!("{HELP}");
+        return Ok(());
+    }
+
+    if args.version {
+        println!("jsonrepair {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
+    let input = read_input(args.input.as_deref())?;
+    let repaired = jsonrepair(&input)?;
+
+    if let Some(path) = args.output {
+        fs::write(&path, repaired).map_err(|source| CliError::Io {
+            action: format!("failed to write {}", path.display()),
+            source,
+        })?;
+    } else {
+        io::stdout()
+            .write_all(repaired.as_bytes())
+            .map_err(|source| CliError::Io {
+                action: "failed to write stdout".to_string(),
+                source,
+            })?;
+    }
+
+    Ok(())
+}
+
+fn read_input(path: Option<&Path>) -> Result<String, CliError> {
+    match path {
+        Some(path) if path != Path::new("-") => {
+            fs::read_to_string(path).map_err(|source| CliError::Io {
+                action: format!("failed to read {}", path.display()),
+                source,
+            })
+        }
+        _ => {
+            let mut input = String::new();
+            io::stdin()
+                .read_to_string(&mut input)
+                .map_err(|source| CliError::Io {
+                    action: "failed to read stdin".to_string(),
+                    source,
+                })?;
+            Ok(input)
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct Args {
+    input: Option<PathBuf>,
+    output: Option<PathBuf>,
+    help: bool,
+    version: bool,
+}
+
+impl Args {
+    fn parse(raw_args: impl IntoIterator<Item = OsString>) -> Result<Self, CliError> {
+        let mut args = Self::default();
+        let mut raw_args = raw_args.into_iter();
+
+        while let Some(arg) = raw_args.next() {
+            if arg == OsStr::new("-h") || arg == OsStr::new("--help") {
+                args.help = true;
+            } else if arg == OsStr::new("-V") || arg == OsStr::new("--version") {
+                args.version = true;
+            } else if arg == OsStr::new("-o") || arg == OsStr::new("--output") {
+                let output = raw_args.next().ok_or_else(|| {
+                    CliError::Usage("--output requires a path argument".to_string())
+                })?;
+                args.output = Some(PathBuf::from(output));
+            } else if let Some(output) = parse_output_equals(&arg) {
+                args.output = Some(PathBuf::from(output));
+            } else if looks_like_unknown_option(&arg) {
+                return Err(CliError::Usage(format!(
+                    "unknown option {}",
+                    display_arg(&arg)
+                )));
+            } else if args.input.replace(PathBuf::from(&arg)).is_some() {
+                return Err(CliError::Usage(
+                    "expected at most one input file".to_string(),
+                ));
+            }
+        }
+
+        Ok(args)
+    }
+}
+
+fn parse_output_equals(arg: &OsStr) -> Option<OsString> {
+    let arg = arg.to_str()?;
+    arg.strip_prefix("--output=").map(OsString::from)
+}
+
+fn looks_like_unknown_option(arg: &OsStr) -> bool {
+    arg.to_str()
+        .is_some_and(|arg| arg.starts_with('-') && arg != "-")
+}
+
+fn display_arg(arg: &OsStr) -> String {
+    arg.to_string_lossy().into_owned()
+}
+
+#[derive(Debug)]
+enum CliError {
+    Usage(String),
+    Io { action: String, source: io::Error },
+    Repair(JsonRepairError),
+}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Usage(message) => f.write_str(message),
+            Self::Io { action, source } => write!(f, "{action}: {source}"),
+            Self::Repair(err) => err.fmt(f),
+        }
+    }
+}
+
+impl From<JsonRepairError> for CliError {
+    fn from(err: JsonRepairError) -> Self {
+        Self::Repair(err)
+    }
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,0 +1,95 @@
+use std::{
+    env, fs,
+    io::Write,
+    path::PathBuf,
+    process::{Command, Stdio},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_jsonrepair")
+}
+
+fn temp_path(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    env::temp_dir().join(format!(
+        "jsonrepair-rs-{name}-{}-{nanos}",
+        std::process::id()
+    ))
+}
+
+#[test]
+fn repairs_stdin_to_stdout() {
+    let mut child = Command::new(bin())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"{name: 'Ada', active: True}")
+        .unwrap();
+
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        r#"{"name": "Ada", "active": true}"#
+    );
+    assert!(output.stderr.is_empty(), "{output:?}");
+}
+
+#[test]
+fn repairs_file_to_output_file() {
+    let input_path = temp_path("input");
+    let output_path = temp_path("output");
+    fs::write(&input_path, "{skills: ['Rust',], ok: False}").unwrap();
+
+    let output = Command::new(bin())
+        .arg(&input_path)
+        .arg("--output")
+        .arg(&output_path)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        fs::read_to_string(&output_path).unwrap(),
+        r#"{"skills": ["Rust"], "ok": false}"#
+    );
+    assert!(output.stdout.is_empty(), "{output:?}");
+
+    let _ = fs::remove_file(input_path);
+    let _ = fs::remove_file(output_path);
+}
+
+#[test]
+fn reports_repair_errors() {
+    let mut child = Command::new(bin())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(br#""\u00""#)
+        .unwrap();
+
+    let output = child.wait_with_output().unwrap();
+
+    assert!(!output.status.success(), "{output:?}");
+    assert!(output.stdout.is_empty(), "{output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("JSON repair error"));
+}


### PR DESCRIPTION
## Summary

- add a `jsonrepair` CLI binary with stdin/file input and optional `--output` support
- add help/version handling and clear non-zero exits for usage, IO, and repair failures
- document CLI installation and usage, and add integration tests for stdin, file output, and repair errors

Closes #2

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-targets`