### PR TITLE
Prepare v0.2.0 release and streaming MVP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+## 0.2.0 - 2026-04-27
+
+Release notes suitable for a GitHub Release are also available at
+[`docs/releases/v0.2.0.md`](docs/releases/v0.2.0.md).
+
+### Added
+
+- Added the `jsonrepair` command-line binary for repairing stdin or files.
+- Added `jsonrepair_to_writer` for writing repaired JSON to any
+  `std::io::Write` destination.
+- Added `jsonrepair_reader_to_writer` as the first streaming-oriented
+  `Read -> Write` API.
+- Added optional `serde` feature helpers:
+  - `jsonrepair_value`
+  - `jsonrepair_parse`
+  - `JsonRepairParseError`
+- Added `JsonRepairWriteError` and `JsonRepairStreamError` for distinguishing
+  repair failures from IO failures.
+- Added an upstream-style parity fixture corpus under `tests/fixtures/`.
+
+### Changed
+
+- Bumped the crate version to `0.2.0`.
+- The CLI now uses the reader-to-writer repair API internally.
+
+### Compatibility
+
+- This release is intended to be source-compatible with `0.1.x` for existing
+  `jsonrepair` callers.
+- New public error enums are marked `#[non_exhaustive]`; downstream code should
+  include fallback match arms.
+- `jsonrepair_reader_to_writer` is an IO convenience MVP, not a true
+  constant-memory streaming parser. It currently buffers complete input and
+  repaired output inside the crate before writing.
+
+### Validation
+
+Release validation should run:
+
+```bash
+RUSTFLAGS="-Dwarnings" cargo check --all-targets
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-targets
+cargo doc --no-deps
+cargo package --allow-dirty
+cargo publish --dry-run --allow-dirty
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "jsonrepair-rs"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrepair-rs"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Repair broken JSON — fix quotes, commas, comments, trailing content, and 30+ other issues"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or add it manually:
 
 ```toml
 [dependencies]
-jsonrepair-rs = "0.1.1"
+jsonrepair-rs = "0.2.0"
 ```
 
 Minimum supported Rust version: 1.70.
@@ -92,6 +92,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ```rust
 pub fn jsonrepair(input: &str) -> Result<String, JsonRepairError>
+pub fn jsonrepair_to_writer<W>(input: &str, writer: &mut W) -> Result<(), JsonRepairWriteError>
+pub fn jsonrepair_reader_to_writer<R, W>(reader: R, writer: &mut W) -> Result<(), JsonRepairStreamError>
 ```
 
 Exports:
@@ -99,13 +101,37 @@ Exports:
 - `jsonrepair` repairs one input string.
 - `jsonrepair_to_writer` repairs one input string and writes the result to any
   `std::io::Write`.
+- `jsonrepair_reader_to_writer` repairs text from any `std::io::Read` and
+  writes the result to any `std::io::Write`.
 - `JsonRepairError` contains `message`, `position`, `kind`, `line`, and `column`.
 - `JsonRepairErrorKind` is a non-exhaustive enum for programmatic error handling.
 - `JsonRepairWriteError` distinguishes repair failures from output write
   failures in writer-based workflows.
+- `JsonRepairStreamError` distinguishes input read failures, repair failures,
+  and output write failures in reader-to-writer workflows.
 
 The output is valid JSON when the function returns `Ok(...)`. When the input
 cannot be repaired safely, the function returns an error instead of guessing.
+
+The reader-to-writer API is streaming-oriented at the IO boundary, but the
+current parser still buffers complete input and repaired output internally. See
+[`docs/streaming-api.md`](docs/streaming-api.md) for the design and memory
+tradeoffs.
+
+Repair a file into another file:
+
+```rust,no_run
+use std::fs::File;
+use jsonrepair_rs::jsonrepair_reader_to_writer;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut input = File::open("broken.json")?;
+    let mut output = File::create("repaired.json")?;
+
+    jsonrepair_reader_to_writer(&mut input, &mut output)?;
+    Ok(())
+}
+```
 
 ## What It Repairs
 
@@ -165,7 +191,9 @@ them outside this crate.
 - Maximum supported nesting depth is 512.
 - The crate preserves much of the original whitespace where possible.
 - It returns a repaired JSON string, not a `serde_json::Value`.
-- It does not provide streaming repair.
+- The `jsonrepair_reader_to_writer` API supports reader-to-writer workflows,
+  but `0.2.0` still buffers internally instead of performing constant-memory
+  repair.
 - It is designed for practical repair, not for accepting arbitrary unsafe input
   as if it were trustworthy. Validate the repaired data according to your
   application's schema before using it.
@@ -286,12 +314,18 @@ instead of reporting a false regression.
 
 ## Release Status
 
-The latest crate published on crates.io is `0.1.1`.
+This branch prepares `0.2.0`. The latest crate published on crates.io remains
+`0.1.1` until the release is published.
 
 To publish a new release, first bump the version in `Cargo.toml` and update any
-version references in this README. Then run:
+version references in this README. Then follow
+[`docs/release-checklist.md`](docs/release-checklist.md). The minimum local
+gate is:
 
 ```bash
+RUSTFLAGS="-Dwarnings" cargo check --all-targets
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
 cargo test --all-targets
 cargo doc --no-deps
 cargo package

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,74 @@
+# Release Checklist
+
+This checklist is for preparing and validating a crates.io release.
+
+## Prepare
+
+1. Confirm `Cargo.toml` has the intended version.
+2. Confirm `CHANGELOG.md` includes a release entry.
+3. Confirm `docs/releases/vX.Y.Z.md` is suitable to paste into a GitHub
+   Release.
+4. Confirm README installation snippets reference the intended crate version.
+5. Confirm all public APIs added in the release are documented in README and
+   rustdoc.
+
+## Validate
+
+Run the CI-equivalent checks:
+
+```bash
+RUSTFLAGS="-Dwarnings" cargo check --all-targets
+cargo fmt --all -- --check
+cargo test --all-targets
+cargo doc --no-deps
+```
+
+Run the stronger local gate before publishing:
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+cargo package --allow-dirty
+```
+
+Inspect the generated package:
+
+```bash
+cargo package --list --allow-dirty
+```
+
+The package should include the source, tests, README, license, changelog, and
+release docs. It should not include local build outputs, `.omx` state, or
+target artifacts.
+
+## Publish Dry Run
+
+Run:
+
+```bash
+cargo publish --dry-run --allow-dirty
+```
+
+Use `--allow-dirty` only while validating an unreleased branch. For the actual
+publish, use a clean tagged checkout and omit `--allow-dirty`.
+
+## Publish
+
+1. Ensure the release PR has merged.
+2. Pull the latest `main`.
+3. Verify the worktree is clean.
+4. Run the validation commands again without `--allow-dirty` where possible.
+5. Publish:
+
+   ```bash
+   cargo publish
+   ```
+
+6. Create and push the release tag:
+
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+7. Create the GitHub Release using `docs/releases/vX.Y.Z.md`.
+8. Confirm crates.io and docs.rs show the new version.

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,0 +1,48 @@
+# jsonrepair-rs 0.2.0
+
+This release collects the first public expansion beyond the original string API:
+CLI usage, writer-based output, serde-powered parse helpers, and a
+streaming-oriented IO helper.
+
+## Highlights
+
+- New `jsonrepair` CLI binary:
+  - repair stdin to stdout
+  - repair an input file to stdout
+  - repair an input file to `--output <path>`
+- New writer API:
+  - `jsonrepair_to_writer(input, writer)`
+- New reader-to-writer API:
+  - `jsonrepair_reader_to_writer(reader, writer)`
+- New optional `serde` feature helpers:
+  - `jsonrepair_value(input)`
+  - `jsonrepair_parse::<T>(input)`
+- New public error types:
+  - `JsonRepairWriteError`
+  - `JsonRepairStreamError`
+  - `JsonRepairParseError` with the `serde` feature
+- New parity fixture corpus in `tests/fixtures/parity_cases.json`.
+
+## Compatibility Notes
+
+Existing `jsonrepair(input)` callers should not need code changes.
+
+The new reader-to-writer API is intentionally conservative. It lets callers use
+files, stdin/stdout, and buffers without receiving an owned repaired `String`,
+but the current parser still buffers the full input and repaired output inside
+the crate. A future parser can reduce that memory profile without changing the
+high-level API shape.
+
+## Validation
+
+Run before publishing:
+
+```bash
+RUSTFLAGS="-Dwarnings" cargo check --all-targets
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-targets
+cargo doc --no-deps
+cargo package --allow-dirty
+cargo publish --dry-run --allow-dirty
+```

--- a/docs/streaming-api.md
+++ b/docs/streaming-api.md
@@ -1,0 +1,95 @@
+# Streaming API Design
+
+## Goal
+
+Expose a stable Rust API for repairing JSON-like text from an input stream into
+an output stream, so callers do not have to receive an owned repaired `String`
+when they are already working with files, stdin/stdout, pipes, or other
+`std::io` types.
+
+## MVP API
+
+```rust
+pub fn jsonrepair_reader_to_writer<R, W>(
+    reader: R,
+    writer: &mut W,
+) -> Result<(), JsonRepairStreamError>
+where
+    R: std::io::Read,
+    W: std::io::Write + ?Sized;
+```
+
+The function accepts any sync `std::io::Read` and writes repaired JSON bytes to
+any sync `std::io::Write`.
+
+## Examples
+
+File to file:
+
+```rust,no_run
+use std::fs::File;
+use jsonrepair_rs::jsonrepair_reader_to_writer;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut input = File::open("broken.json")?;
+    let mut output = File::create("repaired.json")?;
+
+    jsonrepair_reader_to_writer(&mut input, &mut output)?;
+    Ok(())
+}
+```
+
+stdin to stdout:
+
+```rust,no_run
+use std::io;
+use jsonrepair_rs::jsonrepair_reader_to_writer;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+
+    jsonrepair_reader_to_writer(stdin.lock(), &mut stdout.lock())?;
+    Ok(())
+}
+```
+
+## Error Model
+
+`JsonRepairStreamError` separates the three failure classes:
+
+- `Read(std::io::Error)` when the source cannot be read as UTF-8 text.
+- `Repair(JsonRepairError)` when the input cannot be repaired safely.
+- `Write(std::io::Error)` when the destination cannot be written.
+
+## Memory Behavior
+
+The `0.2.0` MVP is streaming-oriented at the API boundary, but it is not yet a
+constant-memory streaming parser.
+
+Current behavior:
+
+1. Read the complete input stream into an internal `String`.
+2. Run the existing repair parser.
+3. Buffer the repaired output internally.
+4. Write the repaired JSON to the destination.
+
+This keeps behavior identical to `jsonrepair(input)` and avoids exposing a
+partially repaired output on repair failure. It also means peak memory is still
+roughly proportional to input size plus repaired output size.
+
+## Non-Goals For The MVP
+
+- Async IO support.
+- Partial JSON value emission before the full repair succeeds.
+- Constant-memory repair for arbitrarily large inputs.
+- Changing parser semantics or whitespace preservation.
+- Supporting non-UTF-8 byte streams.
+
+## Future Direction
+
+A true streaming parser can preserve this high-level API while changing the
+implementation underneath. The parser would need explicit rollback windows for
+repairs such as trailing-comma removal and delayed delimiter insertion, plus a
+clear policy for whether repair failures may have already written partial
+output.

--- a/src/bin/jsonrepair.rs
+++ b/src/bin/jsonrepair.rs
@@ -1,13 +1,14 @@
 use std::{
     env,
     ffi::{OsStr, OsString},
-    fmt, fs,
-    io::{self, Read, Write},
+    fmt,
+    fs::File,
+    io::{self, Read},
     path::{Path, PathBuf},
     process,
 };
 
-use jsonrepair_rs::{jsonrepair, JsonRepairError};
+use jsonrepair_rs::{jsonrepair_reader_to_writer, JsonRepairStreamError};
 
 const HELP: &str = "\
 Repair malformed JSON-like text into valid JSON.
@@ -52,45 +53,35 @@ fn run() -> Result<(), CliError> {
         return Ok(());
     }
 
-    let input = read_input(args.input.as_deref())?;
-    let repaired = jsonrepair(&input)?;
-
-    if let Some(path) = args.output {
-        fs::write(&path, repaired).map_err(|source| CliError::Io {
-            action: format!("failed to write {}", path.display()),
+    if let Some(path) = args.input.as_deref().filter(|path| *path != Path::new("-")) {
+        let mut input = File::open(path).map_err(|source| CliError::Io {
+            action: format!("failed to read {}", path.display()),
             source,
         })?;
+        repair_to_output(&mut input, args.output.as_deref())?;
     } else {
-        io::stdout()
-            .write_all(repaired.as_bytes())
-            .map_err(|source| CliError::Io {
-                action: "failed to write stdout".to_string(),
-                source,
-            })?;
+        let stdin = io::stdin();
+        let mut input = stdin.lock();
+        repair_to_output(&mut input, args.output.as_deref())?;
     }
 
     Ok(())
 }
 
-fn read_input(path: Option<&Path>) -> Result<String, CliError> {
-    match path {
-        Some(path) if path != Path::new("-") => {
-            fs::read_to_string(path).map_err(|source| CliError::Io {
-                action: format!("failed to read {}", path.display()),
-                source,
-            })
-        }
-        _ => {
-            let mut input = String::new();
-            io::stdin()
-                .read_to_string(&mut input)
-                .map_err(|source| CliError::Io {
-                    action: "failed to read stdin".to_string(),
-                    source,
-                })?;
-            Ok(input)
-        }
+fn repair_to_output(input: &mut dyn Read, output_path: Option<&Path>) -> Result<(), CliError> {
+    if let Some(path) = output_path {
+        let mut output = File::create(path).map_err(|source| CliError::Io {
+            action: format!("failed to write {}", path.display()),
+            source,
+        })?;
+        jsonrepair_reader_to_writer(input, &mut output)?;
+    } else {
+        let stdout = io::stdout();
+        let mut output = stdout.lock();
+        jsonrepair_reader_to_writer(input, &mut output)?;
     }
+
+    Ok(())
 }
 
 #[derive(Debug, Default)]
@@ -152,7 +143,7 @@ fn display_arg(arg: &OsStr) -> String {
 enum CliError {
     Usage(String),
     Io { action: String, source: io::Error },
-    Repair(JsonRepairError),
+    Repair(JsonRepairStreamError),
 }
 
 impl fmt::Display for CliError {
@@ -165,8 +156,8 @@ impl fmt::Display for CliError {
     }
 }
 
-impl From<JsonRepairError> for CliError {
-    fn from(err: JsonRepairError) -> Self {
+impl From<JsonRepairStreamError> for CliError {
+    fn from(err: JsonRepairStreamError) -> Self {
         Self::Repair(err)
     }
 }

--- a/src/bin/jsonrepair.rs
+++ b/src/bin/jsonrepair.rs
@@ -1,7 +1,7 @@
 use std::{
     env,
     ffi::{OsStr, OsString},
-    fmt,
+    fmt, fs,
     fs::File,
     io::{self, Read},
     path::{Path, PathBuf},
@@ -70,11 +70,13 @@ fn run() -> Result<(), CliError> {
 
 fn repair_to_output(input: &mut dyn Read, output_path: Option<&Path>) -> Result<(), CliError> {
     if let Some(path) = output_path {
-        let mut output = File::create(path).map_err(|source| CliError::Io {
+        let mut repaired = Vec::new();
+        jsonrepair_reader_to_writer(input, &mut repaired)?;
+
+        fs::write(path, repaired).map_err(|source| CliError::Io {
             action: format!("failed to write {}", path.display()),
             source,
         })?;
-        jsonrepair_reader_to_writer(input, &mut output)?;
     } else {
         let stdout = io::stdout();
         let mut output = stdout.lock();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,38 @@ impl From<std::io::Error> for JsonRepairWriteError {
     }
 }
 
+/// Error returned by reader-to-writer repair helpers.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum JsonRepairStreamError {
+    /// The input stream could not be read as UTF-8 text.
+    Read(std::io::Error),
+    /// The input could not be repaired safely.
+    Repair(JsonRepairError),
+    /// The repaired JSON could not be written to the destination.
+    Write(std::io::Error),
+}
+
+impl std::fmt::Display for JsonRepairStreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Read(err) => write!(f, "failed to read JSON input: {err}"),
+            Self::Repair(err) => err.fmt(f),
+            Self::Write(err) => write!(f, "failed to write repaired JSON: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for JsonRepairStreamError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Read(err) => Some(err),
+            Self::Repair(err) => Some(err),
+            Self::Write(err) => Some(err),
+        }
+    }
+}
+
 /// Repair a broken JSON string and write the valid JSON to a writer.
 ///
 /// This is a writer convenience API. It repairs the input first, then writes
@@ -81,6 +113,34 @@ where
 {
     let repaired = jsonrepair(input)?;
     writer.write_all(repaired.as_bytes())?;
+    Ok(())
+}
+
+/// Repair JSON-like text from a reader and write valid JSON to a writer.
+///
+/// This is the first streaming-oriented API surface: callers can connect files,
+/// stdin, stdout, sockets, or buffers without receiving an owned repaired
+/// [`String`]. The current parser still needs the complete input and repaired
+/// output buffered inside the crate before writing; this preserves exact repair
+/// behavior while leaving room for a future lower-memory parser.
+pub fn jsonrepair_reader_to_writer<R, W>(
+    mut reader: R,
+    writer: &mut W,
+) -> Result<(), JsonRepairStreamError>
+where
+    R: std::io::Read,
+    W: std::io::Write + ?Sized,
+{
+    let mut input = String::new();
+    reader
+        .read_to_string(&mut input)
+        .map_err(JsonRepairStreamError::Read)?;
+
+    let repaired = jsonrepair(&input).map_err(JsonRepairStreamError::Repair)?;
+    writer
+        .write_all(repaired.as_bytes())
+        .map_err(JsonRepairStreamError::Write)?;
+
     Ok(())
 }
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -93,3 +93,26 @@ fn reports_repair_errors() {
     assert!(output.stdout.is_empty(), "{output:?}");
     assert!(String::from_utf8_lossy(&output.stderr).contains("JSON repair error"));
 }
+
+#[test]
+fn repair_error_does_not_truncate_existing_output_file() {
+    let input_path = temp_path("invalid-input");
+    let output_path = temp_path("existing-output");
+    fs::write(&input_path, br#""\u00""#).unwrap();
+    fs::write(&output_path, "keep me").unwrap();
+
+    let output = Command::new(bin())
+        .arg(&input_path)
+        .arg("--output")
+        .arg(&output_path)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{output:?}");
+    assert!(output.stdout.is_empty(), "{output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("JSON repair error"));
+    assert_eq!(fs::read_to_string(&output_path).unwrap(), "keep me");
+
+    let _ = fs::remove_file(input_path);
+    let _ = fs::remove_file(output_path);
+}

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,19 @@
+# Parity Fixtures
+
+`parity_cases.json` stores representative repair cases for behavior parity
+tracking against upstream-style `jsonrepair` inputs.
+
+Each case has:
+
+- `name`: stable case identifier.
+- `category`: broad repair category.
+- `input`: malformed or valid JSON-like input.
+- `expected`: expected `jsonrepair-rs` output.
+- `source`: where the case came from, such as `upstream-representative` or
+  `project-regression`.
+- `divergence`: `null` when behavior is expected to match upstream-style
+  behavior. When behavior intentionally differs, set this to an object with a
+  short `name` and `reason`.
+
+The Rust fixture test validates every case and requires intentional divergences
+to be named and justified.

--- a/tests/fixtures/parity_cases.json
+++ b/tests/fixtures/parity_cases.json
@@ -1,0 +1,157 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "name": "valid-object-pass-through",
+      "category": "valid-json",
+      "input": "{\"a\":2}",
+      "expected": "{\"a\":2}",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "single-quotes",
+      "category": "quotes",
+      "input": "{'name': 'Ada'}",
+      "expected": "{\"name\": \"Ada\"}",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "comments",
+      "category": "comments",
+      "input": "{\n// comment\n\"a\": 1\n}",
+      "expected": "{\n\n\"a\": 1\n}",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "missing-comma-object",
+      "category": "missing-commas",
+      "input": "{\"a\": 1 \"b\": 2}",
+      "expected": "{\"a\": 1, \"b\": 2}",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "missing-comma-array",
+      "category": "missing-commas",
+      "input": "[1 2 3]",
+      "expected": "[1, 2, 3]",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "trailing-comma-object",
+      "category": "trailing-commas",
+      "input": "{\"a\": 1, \"b\": 2,}",
+      "expected": "{\"a\": 1, \"b\": 2}",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "truncated-object",
+      "category": "truncation",
+      "input": "{\"a\": 1, \"b\": 2",
+      "expected": "{\"a\": 1, \"b\": 2}",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "truncated-array",
+      "category": "truncation",
+      "input": "[1, 2, 3",
+      "expected": "[1, 2, 3]",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "truncated-string",
+      "category": "truncation",
+      "input": "\"hello",
+      "expected": "\"hello\"",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "jsonp-callback",
+      "category": "jsonp",
+      "input": "callback({\"a\": 1});",
+      "expected": "{\"a\": 1}",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "mongodb-object-id",
+      "category": "mongodb",
+      "input": "{\"_id\": ObjectId(\"123abc\")}",
+      "expected": "{\"_id\": \"123abc\"}",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "mongodb-number-long",
+      "category": "mongodb",
+      "input": "{\"count\": NumberLong(\"42\")}",
+      "expected": "{\"count\": \"42\"}",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "ndjson-two-objects",
+      "category": "ndjson",
+      "input": "{\"a\":1}\n{\"b\":2}",
+      "expected": "[\n{\"a\":1},\n{\"b\":2}\n]",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "markdown-json-fence",
+      "category": "llm-markdown",
+      "input": "```json\n{\"a\": 1}\n```",
+      "expected": "\n{\"a\": 1}\n",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "llm-fenced-python-keywords",
+      "category": "llm-markdown",
+      "input": "```json\n{name: 'Ada', active: True, notes: None,}\n```",
+      "expected": "\n{\"name\": \"Ada\", \"active\": true, \"notes\": null}\n",
+      "source": "project-regression",
+      "divergence": null
+    },
+    {
+      "name": "unquoted-url",
+      "category": "urls",
+      "input": "{url:https://www.bible.com/}",
+      "expected": "{\"url\":\"https://www.bible.com/\"}",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "regex-token",
+      "category": "regex-like",
+      "input": "{regex: /standalone-styles.css/}",
+      "expected": "{\"regex\": \"/standalone-styles.css/\"}",
+      "source": "project-regression",
+      "divergence": null
+    },
+    {
+      "name": "ellipsis-array",
+      "category": "ellipsis",
+      "input": "[1,2,3,...]",
+      "expected": "[1,2,3]",
+      "source": "upstream-representative",
+      "divergence": null
+    },
+    {
+      "name": "python-keywords",
+      "category": "keywords",
+      "input": "{\"flag\": True, \"value\": None}",
+      "expected": "{\"flag\": true, \"value\": null}",
+      "source": "upstream-representative",
+      "divergence": null
+    }
+  ]
+}

--- a/tests/parity_fixture_tests.rs
+++ b/tests/parity_fixture_tests.rs
@@ -1,0 +1,56 @@
+use jsonrepair_rs::jsonrepair;
+use serde_json::Value;
+
+const CORPUS: &str = include_str!("fixtures/parity_cases.json");
+
+#[test]
+fn parity_fixture_corpus_repairs_expected_cases() {
+    let corpus: Value = serde_json::from_str(CORPUS).unwrap();
+    assert_eq!(corpus["schema_version"], 1);
+
+    let cases = corpus["cases"]
+        .as_array()
+        .expect("parity corpus must contain a cases array");
+
+    assert!(!cases.is_empty(), "parity corpus should not be empty");
+
+    for case in cases {
+        let name = required_str(case, "name");
+        let category = required_str(case, "category");
+        let input = required_str(case, "input");
+        let expected = required_str(case, "expected");
+
+        validate_divergence_metadata(name, case);
+
+        let repaired =
+            jsonrepair(input).unwrap_or_else(|err| panic!("{name} ({category}) failed: {err}"));
+
+        assert_eq!(
+            repaired, expected,
+            "parity fixture {name} ({category}) did not match"
+        );
+    }
+}
+
+fn required_str<'a>(case: &'a Value, field: &str) -> &'a str {
+    case[field]
+        .as_str()
+        .unwrap_or_else(|| panic!("parity case must include string field `{field}`: {case:?}"))
+}
+
+fn validate_divergence_metadata(name: &str, case: &Value) {
+    match &case["divergence"] {
+        Value::Null => {}
+        Value::Object(divergence) => {
+            assert!(
+                divergence.get("name").and_then(Value::as_str).is_some(),
+                "parity case {name} divergence must include a name"
+            );
+            assert!(
+                divergence.get("reason").and_then(Value::as_str).is_some(),
+                "parity case {name} divergence must include a reason"
+            );
+        }
+        _ => panic!("parity case {name} divergence must be null or an object"),
+    }
+}

--- a/tests/streaming_tests.rs
+++ b/tests/streaming_tests.rs
@@ -1,0 +1,116 @@
+use std::io::{self, Cursor, Read, Write};
+
+use jsonrepair_rs::{jsonrepair, jsonrepair_reader_to_writer, JsonRepairStreamError};
+
+#[test]
+fn repairs_reader_to_writer() {
+    let mut input = Cursor::new("{name: 'Ada', active: True}");
+    let mut output = Vec::new();
+
+    jsonrepair_reader_to_writer(&mut input, &mut output).unwrap();
+
+    assert_eq!(
+        String::from_utf8(output).unwrap(),
+        r#"{"name": "Ada", "active": true}"#
+    );
+}
+
+#[test]
+fn matches_string_api_for_file_sized_input() {
+    let mut lines = Vec::new();
+    for index in 0..2048 {
+        lines.push(format!("{{id:{index}, name:'item-{index}', ok: True,}}"));
+    }
+    let input = lines.join("\n");
+
+    let mut reader = ChunkedReader::new(input.as_bytes(), 17);
+    let mut output = Vec::new();
+
+    jsonrepair_reader_to_writer(&mut reader, &mut output).unwrap();
+
+    let streamed = String::from_utf8(output).unwrap();
+    assert_eq!(streamed, jsonrepair(&input).unwrap());
+    serde_json::from_str::<serde_json::Value>(&streamed).unwrap();
+}
+
+#[test]
+fn preserves_repair_errors_without_partial_output() {
+    let mut input = Cursor::new(br#""\u00""#);
+    let mut output = Vec::new();
+
+    let err = jsonrepair_reader_to_writer(&mut input, &mut output).unwrap_err();
+
+    assert!(matches!(err, JsonRepairStreamError::Repair(_)));
+    assert!(output.is_empty());
+}
+
+#[test]
+fn reports_read_errors() {
+    let mut output = Vec::new();
+    let err = jsonrepair_reader_to_writer(FailingReader, &mut output).unwrap_err();
+
+    assert!(matches!(err, JsonRepairStreamError::Read(_)));
+    assert!(output.is_empty());
+}
+
+#[test]
+fn reports_write_errors() {
+    let input = Cursor::new("{name: 'Ada'}");
+    let mut output = FailingWriter;
+
+    let err = jsonrepair_reader_to_writer(input, &mut output).unwrap_err();
+
+    assert!(matches!(err, JsonRepairStreamError::Write(_)));
+}
+
+struct ChunkedReader<'a> {
+    input: &'a [u8],
+    chunk_size: usize,
+    offset: usize,
+}
+
+impl<'a> ChunkedReader<'a> {
+    fn new(input: &'a [u8], chunk_size: usize) -> Self {
+        Self {
+            input,
+            chunk_size,
+            offset: 0,
+        }
+    }
+}
+
+impl Read for ChunkedReader<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.offset >= self.input.len() {
+            return Ok(0);
+        }
+
+        let len = self
+            .chunk_size
+            .min(buf.len())
+            .min(self.input.len() - self.offset);
+        buf[..len].copy_from_slice(&self.input[self.offset..self.offset + len]);
+        self.offset += len;
+        Ok(len)
+    }
+}
+
+struct FailingReader;
+
+impl Read for FailingReader {
+    fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+        Err(io::Error::new(io::ErrorKind::Other, "source closed"))
+    }
+}
+
+struct FailingWriter;
+
+impl Write for FailingWriter {
+    fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+        Err(io::Error::new(io::ErrorKind::Other, "destination closed"))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

- Bump crate metadata to `0.2.0` and add release notes/changelog plus publish dry-run checklist.
- Add `jsonrepair_reader_to_writer` with `JsonRepairStreamError`, document the streaming API design and current buffering tradeoffs, and route the CLI through the new API.
- Add an upstream-style parity fixture corpus with a dedicated corpus test.

Closes #8
Closes #9
Closes #10
Closes #11
Closes #12
Closes #13

## Test plan

- [x] `cargo test --all-targets`
- [x] `cargo test --all-targets --all-features`
- [x] `RUSTFLAGS="-Dwarnings" cargo check --all-targets`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo doc --no-deps`
- [x] `cargo package --allow-dirty`
- [x] `cargo publish --dry-run --allow-dirty`