### PR TITLE
Fix fuzz lockfile version

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "jsonrepair-rs"
-version = "0.1.1"
+version = "0.2.0"
 
 [[package]]
 name = "jsonrepair-rs-fuzz"


### PR DESCRIPTION
## Summary
- update fuzz/Cargo.lock to match the root crate version 0.2.0
- confirm the CLI failed-repair output preservation regression is already covered by test

## Verification
- cargo test --test cli_tests repair_error_does_not_truncate_existing_output_file
- cargo +nightly fuzz build repair_parser