### PR TITLE
Document CLI exit codes and edge cases

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,73 @@
+# Command Line Interface
+
+The `jsonrepair` binary repairs malformed JSON-like text from stdin or a file
+and writes valid JSON to stdout or an output file.
+
+## Usage
+
+```bash
+jsonrepair [OPTIONS] [INPUT_FILE]
+```
+
+When `INPUT_FILE` is omitted, the CLI reads from stdin. Passing `-` as the input
+file also reads from stdin, which is useful when a shell script wants to keep a
+placeholder for the input position.
+
+## Output Behavior
+
+| Command shape | Input | Output |
+| --- | --- | --- |
+| `jsonrepair` | stdin | stdout |
+| `jsonrepair -` | stdin | stdout |
+| `jsonrepair broken.json` | `broken.json` | stdout |
+| `jsonrepair broken.json --output repaired.json` | `broken.json` | `repaired.json` |
+| `jsonrepair --output repaired.json` | stdin | `repaired.json` |
+| `jsonrepair --output=repaired.json` | stdin | `repaired.json` |
+
+When `--output` is used, repair is completed into an internal buffer before the
+destination file is written. If repair fails, an existing output file is left
+unchanged.
+
+## Exit Codes
+
+| Code | Meaning |
+| ---: | --- |
+| `0` | Success, including `--help` and `--version`. |
+| `1` | Input IO error, repair error, or output write error. |
+| `2` | Command-line usage error, such as an unknown option, a missing `--output` path, or more than one input file. |
+
+Error details are written to stderr. Repaired JSON is written to stdout only
+when `--output` is not used.
+
+## Shell Examples
+
+Repair stdin to stdout:
+
+```bash
+printf "{name: 'Ada', active: True}" | jsonrepair
+```
+
+Repair stdin to a file:
+
+```bash
+printf "{name: 'Ada'}" | jsonrepair --output repaired.json
+```
+
+Use `-` as an explicit stdin placeholder:
+
+```bash
+cat broken.json | jsonrepair - --output repaired.json
+```
+
+Handle usage errors separately from repair or IO errors:
+
+```bash
+if ! jsonrepair "$input" --output "$output"; then
+  code=$?
+  if [ "$code" -eq 2 ]; then
+    echo "invalid jsonrepair command line" >&2
+  else
+    echo "jsonrepair could not repair or write the document" >&2
+  fi
+fi
+```

--- a/src/bin/jsonrepair.rs
+++ b/src/bin/jsonrepair.rs
@@ -23,6 +23,11 @@ Options:
   -o, --output PATH   Write repaired JSON to PATH instead of stdout.
   -h, --help          Print help.
   -V, --version       Print version.
+
+Exit Codes:
+  0                   Repaired successfully or printed help/version.
+  1                   Repair, input, or output error.
+  2                   Command-line usage error.
 ";
 
 fn main() {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -116,3 +116,102 @@ fn repair_error_does_not_truncate_existing_output_file() {
     let _ = fs::remove_file(input_path);
     let _ = fs::remove_file(output_path);
 }
+
+#[test]
+fn help_documents_exit_codes() -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new(bin()).arg("--help").output()?;
+
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Exit Codes:"), "{stdout}");
+    assert!(
+        stdout.contains("  2                   Command-line usage error."),
+        "{stdout}"
+    );
+    Ok(())
+}
+
+#[test]
+fn usage_error_exits_2() -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new(bin()).arg("--unknown").output()?;
+
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    assert!(output.stdout.is_empty(), "{output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("unknown option"));
+    Ok(())
+}
+
+#[test]
+fn output_requires_path_exits_2() -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new(bin()).arg("--output").output()?;
+
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    assert!(output.stdout.is_empty(), "{output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("requires a path"));
+    Ok(())
+}
+
+#[test]
+fn dash_reads_stdin_to_output_file() -> Result<(), Box<dyn std::error::Error>> {
+    let output_path = temp_path("dash-output");
+    let mut child = Command::new(bin())
+        .arg("-")
+        .arg("--output")
+        .arg(&output_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(b"{name: 'Ada', active: True}")?;
+    } else {
+        return Err(
+            std::io::Error::new(std::io::ErrorKind::Other, "stdin pipe was unavailable").into(),
+        );
+    }
+
+    let output = child.wait_with_output()?;
+
+    assert!(output.status.success(), "{output:?}");
+    assert!(output.stdout.is_empty(), "{output:?}");
+    assert_eq!(
+        fs::read_to_string(&output_path)?,
+        r#"{"name": "Ada", "active": true}"#
+    );
+
+    let _ = fs::remove_file(output_path);
+    Ok(())
+}
+
+#[test]
+fn output_equals_writes_file() -> Result<(), Box<dyn std::error::Error>> {
+    let output_path = temp_path("equals-output");
+    let output_arg = format!("--output={}", output_path.display());
+    let mut child = Command::new(bin())
+        .arg(output_arg)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(b"{skills: ['Rust',], ok: False}")?;
+    } else {
+        return Err(
+            std::io::Error::new(std::io::ErrorKind::Other, "stdin pipe was unavailable").into(),
+        );
+    }
+
+    let output = child.wait_with_output()?;
+
+    assert!(output.status.success(), "{output:?}");
+    assert!(output.stdout.is_empty(), "{output:?}");
+    assert_eq!(
+        fs::read_to_string(&output_path)?,
+        r#"{"skills": ["Rust"], "ok": false}"#
+    );
+
+    let _ = fs::remove_file(output_path);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- document CLI stdin, `-`, `--output`, and `--output=...` behavior in `docs/cli.md`
- add exit code details to `jsonrepair --help`
- add CLI regressions for help text, usage code 2, missing output path, explicit stdin, and `--output=...`

Closes #20.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --test cli_tests`
- `cargo test --all-targets --all-features`
- `RUSTFLAGS="-Dwarnings" cargo check --all-targets`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo doc --no-deps`
- `pre-commit run --all-files`