### PR TITLE
Harden CI release validation gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: RUSTFLAGS="-Dwarnings" cargo check --all-targets
       - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test --all-targets
+      - run: cargo test --all-targets --all-features
       - run: cargo doc --no-deps
+      - run: cargo package --allow-dirty

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -19,16 +19,24 @@ Run the CI-equivalent checks:
 ```bash
 RUSTFLAGS="-Dwarnings" cargo check --all-targets
 cargo fmt --all -- --check
-cargo test --all-targets
-cargo doc --no-deps
-```
-
-Run the stronger local gate before publishing:
-
-```bash
 cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-targets
+cargo test --all-targets --all-features
+cargo doc --no-deps
 cargo package --allow-dirty
 ```
+
+Run the publish dry run before publishing:
+
+```bash
+cargo publish --dry-run --allow-dirty
+```
+
+Use `--allow-dirty` only while validating an unreleased branch. For the actual
+publish, use a clean tagged checkout and omit `--allow-dirty`.
+
+Nightly fuzz checks are intentionally not part of the default CI gate. See
+[`docs/fuzzing.md`](fuzzing.md) for the cargo-fuzz smoke run.
 
 Inspect the generated package:
 
@@ -39,17 +47,6 @@ cargo package --list --allow-dirty
 The package should include the source, tests, README, license, changelog, and
 release docs. It should not include local build outputs, `.omx` state, or
 target artifacts.
-
-## Publish Dry Run
-
-Run:
-
-```bash
-cargo publish --dry-run --allow-dirty
-```
-
-Use `--allow-dirty` only while validating an unreleased branch. For the actual
-publish, use a clean tagged checkout and omit `--allow-dirty`.
 
 ## Publish
 


### PR DESCRIPTION
## Summary

- add clippy all-targets/all-features to CI
- add all-features test coverage to CI
- add `cargo package --allow-dirty` to CI and align the release checklist with the automated gate
- keep nightly fuzz checks documented but outside default CI

Closes #30.

## Validation

- `RUSTFLAGS="-Dwarnings" cargo check --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`
- `cargo test --all-targets --all-features`
- `cargo doc --no-deps`
- `cargo package --allow-dirty`
- `pre-commit run --all-files`