### PR TITLE
Add LLM output repair examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [[bench]]
 name = "benchmark"
 harness = false
+
+[[example]]
+name = "llm_typed_parse"
+required-features = ["serde"]

--- a/README.md
+++ b/README.md
@@ -210,10 +210,31 @@ Runnable examples live in `examples/`:
 ```bash
 cargo run --example repair_basic
 cargo run --example repair_and_parse
+cargo run --example llm_output
+cargo run --features serde --example llm_typed_parse
 ```
 
 `repair_basic` repairs and prints a malformed JSON-like string.
 `repair_and_parse` repairs a string and then parses it with `serde_json`.
+`llm_output` repairs an LLM-style response that has prose around a JSON-like
+object. The prose is preserved as strings in a valid JSON array, so callers can
+inspect or extract the object they need.
+`llm_typed_parse` repairs a markdown-fenced JSON object and deserializes it into
+a typed struct with the `serde` feature enabled.
+
+For a shell pipeline, pass fenced JSON through the CLI:
+
+````bash
+printf '```json
+{name: "Ada", active: True, skills: ["rust",],}
+```' | jsonrepair
+````
+
+This prints valid JSON for the fenced object:
+
+```json
+{"name": "Ada", "active": true, "skills": ["rust"]}
+```
 
 ## Feature Flags
 

--- a/examples/llm_output.rs
+++ b/examples/llm_output.rs
@@ -1,0 +1,22 @@
+use jsonrepair_rs::jsonrepair;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let llm_output = r#"The model returned this object:
+{name: 'Ada', active: True, skills: ['rust', 'json',],}
+Use it for the profile card."#;
+
+    let repaired = jsonrepair(llm_output)?;
+    let value: serde_json::Value = serde_json::from_str(&repaired)?;
+
+    let profile = value
+        .as_array()
+        .and_then(|items| items.iter().find(|item| item.get("name").is_some()))
+        .expect("repaired LLM output should contain the profile object");
+
+    assert_eq!(profile["name"], "Ada");
+    assert_eq!(profile["active"], true);
+    assert_eq!(profile["skills"][0], "rust");
+
+    println!("{repaired}");
+    Ok(())
+}

--- a/examples/llm_typed_parse.rs
+++ b/examples/llm_typed_parse.rs
@@ -1,0 +1,28 @@
+use jsonrepair_rs::jsonrepair_parse;
+
+#[derive(Debug, PartialEq, serde::Deserialize)]
+struct Profile {
+    name: String,
+    active: bool,
+    skills: Vec<String>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let fenced_json = r#"```json
+{name: 'Ada', active: True, skills: ['rust', 'json',],}
+```"#;
+
+    let profile: Profile = jsonrepair_parse(fenced_json)?;
+
+    assert_eq!(
+        profile,
+        Profile {
+            name: "Ada".to_string(),
+            active: true,
+            skills: vec!["rust".to_string(), "json".to_string()],
+        }
+    );
+
+    println!("{profile:?}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- add runnable examples for LLM-style prose-wrapped output and markdown-fenced typed parsing
- document the new examples in README, including a CLI fenced-JSON pipeline
- mark the serde typed example with the required feature so all-target builds stay correct

Closes #21.

## Validation

- `cargo fmt --all -- --check`
- `cargo run --quiet --example llm_output`
- `cargo run --quiet --features serde --example llm_typed_parse`
- `cargo test --all-targets`
- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- `RUSTFLAGS="-Dwarnings" cargo check --all-targets`