### PR TITLE
Add repair options and streaming design tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,19 +92,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ```rust
 pub fn jsonrepair(input: &str) -> Result<String, JsonRepairError>
+pub fn jsonrepair_with_options(input: &str, options: RepairOptions) -> Result<String, JsonRepairError>
 pub fn jsonrepair_to_writer<W>(input: &str, writer: &mut W) -> Result<(), JsonRepairWriteError>
+pub fn jsonrepair_to_writer_with_options<W>(input: &str, writer: &mut W, options: RepairOptions) -> Result<(), JsonRepairWriteError>
 pub fn jsonrepair_reader_to_writer<R, W>(reader: R, writer: &mut W) -> Result<(), JsonRepairStreamError>
+pub fn jsonrepair_reader_to_writer_with_options<R, W>(reader: R, writer: &mut W, options: RepairOptions) -> Result<(), JsonRepairStreamError>
 pub fn jsonrepair_value(input: &str) -> Result<serde_json::Value, JsonRepairParseError>
+pub fn jsonrepair_value_with_options(input: &str, options: RepairOptions) -> Result<serde_json::Value, JsonRepairParseError>
 pub fn jsonrepair_parse<T>(input: &str) -> Result<T, JsonRepairParseError>
+pub fn jsonrepair_parse_with_options<T>(input: &str, options: RepairOptions) -> Result<T, JsonRepairParseError>
 ```
 
 | API | Feature | Returns | Failure modes |
 | --- | --- | --- | --- |
 | `jsonrepair(input)` | default | repaired JSON `String` | `JsonRepairError` when input cannot be repaired safely |
+| `jsonrepair_with_options(input, options)` | default | repaired JSON `String` with explicit policy | `JsonRepairError`, including `StrictModeViolation` in strict mode |
 | `jsonrepair_to_writer(input, writer)` | default | writes repaired JSON to `std::io::Write` | `JsonRepairWriteError::Repair` or `JsonRepairWriteError::Write` |
+| `jsonrepair_to_writer_with_options(input, writer, options)` | default | writes with explicit policy | `JsonRepairWriteError::Repair` or `JsonRepairWriteError::Write` |
 | `jsonrepair_reader_to_writer(reader, writer)` | default | reads from `std::io::Read`, writes to `std::io::Write` | `JsonRepairStreamError::Read`, `Repair`, or `Write` |
+| `jsonrepair_reader_to_writer_with_options(reader, writer, options)` | default | streams with explicit policy | `JsonRepairStreamError::Read`, `Repair`, or `Write` |
 | `jsonrepair_value(input)` | `serde` | repaired `serde_json::Value` | `JsonRepairParseError::Repair` or `JsonRepairParseError::Parse` |
+| `jsonrepair_value_with_options(input, options)` | `serde` | repaired `serde_json::Value` with explicit policy | `JsonRepairParseError::Repair` or `JsonRepairParseError::Parse` |
 | `jsonrepair_parse<T>(input)` | `serde` | repaired and deserialized `T` | `JsonRepairParseError::Repair` or `JsonRepairParseError::Parse` |
+| `jsonrepair_parse_with_options<T>(input, options)` | `serde` | repaired and deserialized `T` with explicit policy | `JsonRepairParseError::Repair` or `JsonRepairParseError::Parse` |
 
 Supporting types:
 
@@ -117,6 +127,8 @@ Supporting types:
 
 The output is valid JSON when the function returns `Ok(...)`. When the input
 cannot be repaired safely, the function returns an error instead of guessing.
+Use [`RepairOptions::strict`](docs/repair-options.md) when callers want valid
+JSON pass-through and an error for repairable non-standard input.
 
 The reader-to-writer API is streaming-oriented at the IO boundary, but the
 current parser still buffers complete input and repaired output internally. See

--- a/docs/repair-options.md
+++ b/docs/repair-options.md
@@ -1,0 +1,76 @@
+# Repair Options
+
+`jsonrepair-rs` defaults to forgiving repair behavior for LLM output, copied JS
+objects, markdown-fenced JSON, and other JSON-like input.
+
+Use `RepairOptions` when the caller needs an explicit policy.
+
+## Default Policy
+
+```rust
+use jsonrepair_rs::{jsonrepair_with_options, RepairOptions};
+
+let repaired = jsonrepair_with_options(
+    "{name: 'Ada', active: True}",
+    RepairOptions::default(),
+)?;
+assert_eq!(repaired, r#"{"name": "Ada", "active": true}"#);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+`RepairOptions::default()` is equivalent to `jsonrepair(input)`.
+
+## Strict Mode
+
+Strict mode returns valid JSON unchanged and rejects input that would require
+repair:
+
+```rust
+use jsonrepair_rs::{jsonrepair_with_options, JsonRepairErrorKind, RepairOptions};
+
+let valid = r#"{"name": "Ada", "active": true}"#;
+assert_eq!(
+    jsonrepair_with_options(valid, RepairOptions::strict())?,
+    valid
+);
+
+let err = jsonrepair_with_options("{name: 'Ada'}", RepairOptions::strict())
+    .unwrap_err();
+assert_eq!(err.kind, JsonRepairErrorKind::StrictModeViolation);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Use strict mode when accepting user input that should already be JSON, or when a
+caller needs to distinguish "valid as submitted" from "repairable but
+non-standard."
+
+## Supported Helpers
+
+Options are available on the string, writer, reader-to-writer, and serde helper
+surfaces:
+
+```rust
+jsonrepair_with_options(input, options)
+jsonrepair_to_writer_with_options(input, writer, options)
+jsonrepair_reader_to_writer_with_options(reader, writer, options)
+jsonrepair_value_with_options(input, options)
+jsonrepair_parse_with_options::<T>(input, options)
+```
+
+The serde helpers require the `serde` feature.
+
+## Future Policy Toggles
+
+The first options API intentionally exposes only strict mode. Future policy
+fields can be added without breaking `jsonrepair(input)` callers. Candidate
+toggles include:
+
+- comments
+- Python and JavaScript keywords
+- markdown fences
+- JSONP wrappers
+- NDJSON aggregation
+- non-finite numbers
+
+Those toggles should be added only when each policy has representative tests and
+clear default compatibility behavior.

--- a/docs/streaming-api.md
+++ b/docs/streaming-api.md
@@ -93,3 +93,44 @@ implementation underneath. The parser would need explicit rollback windows for
 repairs such as trailing-comma removal and delayed delimiter insertion, plus a
 clear policy for whether repair failures may have already written partial
 output.
+
+## True Streaming Parser Design
+
+A lower-memory parser should move from "read all, repair all, write all" to an
+incremental state machine with explicit commit points. The high-level
+`jsonrepair_reader_to_writer` API can stay source-compatible, but the internal
+parser needs to know when bytes are safe to emit.
+
+Required parser states:
+
+| State | Responsibility | Rollback window |
+| --- | --- | --- |
+| Whitespace/comment scanner | Copy whitespace, skip comments, preserve line info | Until a comment end or newline confirms what to drop. |
+| String scanner | Normalize quotes, escapes, control characters, and missing end quotes | From opening quote through the next safe delimiter. |
+| Number scanner | Repair `.5`, `2.`, `2e`, signed non-finite values | Until token boundary confirms the number shape. |
+| Object scanner | Repair keys, colons, commas, values, and closing braces | At least one property plus trailing whitespace/comma. |
+| Array scanner | Repair commas, values, ellipsis, and closing brackets | At least one item plus trailing whitespace/comma. |
+| Root scanner | Detect NDJSON/root value lists, JSONP, markdown fences, redundant closers | Until the next root token proves list aggregation is needed. |
+
+Commit policy:
+
+1. Do not write partial output before a repair decision is irreversible.
+2. Keep a small pending-output buffer per nesting frame.
+3. Commit a frame only after delimiters, comments, and trailing commas are
+   resolved.
+4. On repair failure, return `JsonRepairStreamError::Repair` without writing
+   partial JSON unless a future API explicitly opts into partial output.
+
+Chunk-boundary tests should cover:
+
+- strings and escapes split at every byte position
+- comments split across `//`, `/*`, and `*/`
+- numbers split across sign, decimal point, exponent, and non-finite keyword
+- trailing commas split before and after whitespace
+- missing delimiters at EOF
+- NDJSON/root value aggregation across chunks
+
+The current tests already assert that a chunked reader produces exactly the same
+output as `jsonrepair(input)` for these categories. A parser rewrite should keep
+those tests and add lower-level state-machine tests before changing memory
+behavior.

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,8 @@ pub enum JsonRepairErrorKind {
     MaxDepthExceeded,
     /// Invalid control character in string.
     InvalidCharacter,
+    /// Strict mode rejected input that required a repair.
+    StrictModeViolation,
 }
 
 /// Error returned when JSON cannot be repaired.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,40 @@ mod parser;
 pub use error::JsonRepairParseError;
 pub use error::{JsonRepairError, JsonRepairErrorKind};
 
+/// Options controlling repair behavior.
+///
+/// The default policy keeps the historical forgiving behavior of
+/// [`jsonrepair`]. Use [`RepairOptions::strict`] when callers want valid JSON
+/// pass-through and an error for any input that would require repair.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RepairOptions {
+    strict: bool,
+}
+
+impl RepairOptions {
+    /// Return the default forgiving repair policy.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return an options value that rejects any input requiring repair.
+    pub fn strict() -> Self {
+        Self { strict: true }
+    }
+
+    /// Enable or disable strict mode.
+    pub fn with_strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
+    }
+
+    /// Whether strict mode is enabled.
+    pub fn is_strict(&self) -> bool {
+        self.strict
+    }
+}
+
 /// Error returned by writer-based repair helpers.
 #[derive(Debug)]
 #[non_exhaustive]
@@ -111,7 +145,19 @@ pub fn jsonrepair_to_writer<W>(input: &str, writer: &mut W) -> Result<(), JsonRe
 where
     W: std::io::Write + ?Sized,
 {
-    let repaired = jsonrepair(input)?;
+    jsonrepair_to_writer_with_options(input, writer, RepairOptions::default())
+}
+
+/// Repair a broken JSON string using options and write the valid JSON to a writer.
+pub fn jsonrepair_to_writer_with_options<W>(
+    input: &str,
+    writer: &mut W,
+    options: RepairOptions,
+) -> Result<(), JsonRepairWriteError>
+where
+    W: std::io::Write + ?Sized,
+{
+    let repaired = jsonrepair_with_options(input, options)?;
     writer.write_all(repaired.as_bytes())?;
     Ok(())
 }
@@ -131,12 +177,26 @@ where
     R: std::io::Read,
     W: std::io::Write + ?Sized,
 {
+    jsonrepair_reader_to_writer_with_options(&mut reader, writer, RepairOptions::default())
+}
+
+/// Repair JSON-like text from a reader using options and write valid JSON to a writer.
+pub fn jsonrepair_reader_to_writer_with_options<R, W>(
+    mut reader: R,
+    writer: &mut W,
+    options: RepairOptions,
+) -> Result<(), JsonRepairStreamError>
+where
+    R: std::io::Read,
+    W: std::io::Write + ?Sized,
+{
     let mut input = String::new();
     reader
         .read_to_string(&mut input)
         .map_err(JsonRepairStreamError::Read)?;
 
-    let repaired = jsonrepair(&input).map_err(JsonRepairStreamError::Repair)?;
+    let repaired =
+        jsonrepair_with_options(&input, options).map_err(JsonRepairStreamError::Repair)?;
     writer
         .write_all(repaired.as_bytes())
         .map_err(JsonRepairStreamError::Write)?;
@@ -165,8 +225,26 @@ where
 ///
 /// Returns `Err(JsonRepairError)` if the input cannot be repaired.
 pub fn jsonrepair(input: &str) -> Result<String, JsonRepairError> {
+    jsonrepair_with_options(input, RepairOptions::default())
+}
+
+/// Repair a JSON string using explicit options.
+///
+/// With default options, this behaves exactly like [`jsonrepair`]. With
+/// [`RepairOptions::strict`], valid JSON is returned unchanged and any input
+/// that would require repair returns [`JsonRepairErrorKind::StrictModeViolation`].
+pub fn jsonrepair_with_options(
+    input: &str,
+    options: RepairOptions,
+) -> Result<String, JsonRepairError> {
     let repairer = parser::JsonRepairer::new(input);
-    repairer.repair()
+    let repaired = repairer.repair()?;
+
+    if options.strict {
+        reject_if_changed(input, &repaired)?;
+    }
+
+    Ok(repaired)
 }
 
 /// Repair a broken JSON string and parse it into [`serde_json::Value`].
@@ -177,6 +255,17 @@ pub fn jsonrepair_value(input: &str) -> Result<serde_json::Value, JsonRepairPars
     jsonrepair_parse(input)
 }
 
+/// Repair a broken JSON string using options and parse it into [`serde_json::Value`].
+///
+/// This helper is available with the `serde` feature.
+#[cfg(feature = "serde")]
+pub fn jsonrepair_value_with_options(
+    input: &str,
+    options: RepairOptions,
+) -> Result<serde_json::Value, JsonRepairParseError> {
+    jsonrepair_parse_with_options(input, options)
+}
+
 /// Repair a broken JSON string and deserialize it into the requested type.
 ///
 /// This helper is available with the `serde` feature.
@@ -185,6 +274,64 @@ pub fn jsonrepair_parse<T>(input: &str) -> Result<T, JsonRepairParseError>
 where
     T: serde::de::DeserializeOwned,
 {
-    let repaired = jsonrepair(input)?;
+    jsonrepair_parse_with_options(input, RepairOptions::default())
+}
+
+/// Repair a broken JSON string using options and deserialize it into the requested type.
+///
+/// This helper is available with the `serde` feature.
+#[cfg(feature = "serde")]
+pub fn jsonrepair_parse_with_options<T>(
+    input: &str,
+    options: RepairOptions,
+) -> Result<T, JsonRepairParseError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let repaired = jsonrepair_with_options(input, options)?;
     serde_json::from_str(&repaired).map_err(JsonRepairParseError::from)
+}
+
+fn reject_if_changed(input: &str, repaired: &str) -> Result<(), JsonRepairError> {
+    if input == repaired {
+        return Ok(());
+    }
+
+    let position = first_difference(input, repaired);
+    let (line, column) = line_column(input, position);
+    Err(JsonRepairError::with_kind(
+        "Strict mode rejected input that requires JSON repair",
+        position,
+        JsonRepairErrorKind::StrictModeViolation,
+    )
+    .with_location(line, column))
+}
+
+fn first_difference(left: &str, right: &str) -> usize {
+    for (index, (left_char, right_char)) in left.chars().zip(right.chars()).enumerate() {
+        if left_char != right_char {
+            return index;
+        }
+    }
+
+    left.chars().count().min(right.chars().count())
+}
+
+fn line_column(input: &str, position: usize) -> (usize, usize) {
+    let mut line = 1;
+    let mut column = 1;
+
+    for (index, ch) in input.chars().enumerate() {
+        if index == position {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+    }
+
+    (line, column)
 }

--- a/tests/options_tests.rs
+++ b/tests/options_tests.rs
@@ -1,0 +1,59 @@
+use jsonrepair_rs::{
+    jsonrepair, jsonrepair_to_writer_with_options, jsonrepair_with_options, JsonRepairErrorKind,
+    RepairOptions,
+};
+
+#[test]
+fn default_options_match_jsonrepair() {
+    let input = "{name: 'Ada', active: True}";
+
+    assert_eq!(
+        jsonrepair_with_options(input, RepairOptions::default()).unwrap(),
+        jsonrepair(input).unwrap()
+    );
+}
+
+#[test]
+fn strict_mode_passes_valid_json_unchanged() {
+    let input = r#"{"name": "Ada", "active": true, "skills": ["rust"]}"#;
+
+    assert_eq!(
+        jsonrepair_with_options(input, RepairOptions::strict()).unwrap(),
+        input
+    );
+}
+
+#[test]
+fn strict_mode_rejects_repairable_inputs() {
+    for input in [
+        "{name: 'Ada'}",
+        "{\n  // comment\n  \"name\": \"Ada\"\n}",
+        "```json\n{\"name\":\"Ada\"}\n```",
+        "{\"active\": True}",
+        "callback({\"name\":\"Ada\"});",
+        "{\"value\": NaN}",
+        "{\"items\": [1,2,]}",
+        "{\"a\":1}\n{\"b\":2}",
+    ] {
+        let err = jsonrepair_with_options(input, RepairOptions::strict())
+            .expect_err(&format!("expected strict error for {input:?}"));
+        assert_eq!(err.kind, JsonRepairErrorKind::StrictModeViolation);
+        assert!(err.line > 0);
+        assert!(err.column > 0);
+    }
+}
+
+#[test]
+fn strict_mode_is_available_for_writer_helpers() {
+    let mut output = Vec::new();
+    let err =
+        jsonrepair_to_writer_with_options("{name: 'Ada'}", &mut output, RepairOptions::strict())
+            .unwrap_err();
+
+    assert!(matches!(
+        err,
+        jsonrepair_rs::JsonRepairWriteError::Repair(repair_err)
+            if repair_err.kind == JsonRepairErrorKind::StrictModeViolation
+    ));
+    assert!(output.is_empty());
+}

--- a/tests/serde_tests.rs
+++ b/tests/serde_tests.rs
@@ -1,6 +1,9 @@
 #![cfg(feature = "serde")]
 
-use jsonrepair_rs::{jsonrepair_parse, jsonrepair_value, JsonRepairParseError};
+use jsonrepair_rs::{
+    jsonrepair_parse, jsonrepair_parse_with_options, jsonrepair_value,
+    jsonrepair_value_with_options, JsonRepairErrorKind, JsonRepairParseError, RepairOptions,
+};
 
 #[test]
 fn repairs_and_returns_value() {
@@ -35,4 +38,26 @@ fn preserves_repair_errors() {
     let err = jsonrepair_value(r#""\u00""#).unwrap_err();
 
     assert!(matches!(err, JsonRepairParseError::Repair(_)));
+}
+
+#[test]
+fn strict_options_apply_to_serde_helpers() {
+    let value = jsonrepair_value_with_options(
+        r#"{"name": "Ada", "active": true}"#,
+        RepairOptions::strict(),
+    )
+    .unwrap();
+    assert_eq!(value["name"], "Ada");
+
+    let err = jsonrepair_parse_with_options::<User>(
+        "{name: 'Ada', active: True}",
+        RepairOptions::strict(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        JsonRepairParseError::Repair(repair_err)
+            if repair_err.kind == JsonRepairErrorKind::StrictModeViolation
+    ));
 }

--- a/tests/streaming_tests.rs
+++ b/tests/streaming_tests.rs
@@ -34,6 +34,34 @@ fn matches_string_api_for_file_sized_input() {
 }
 
 #[test]
+fn chunk_boundary_cases_match_string_api() {
+    let cases = [
+        r#"{"text":"hello\nworld","quote":"a\"b"}"#,
+        "{\n// comment\nname:'Ada', active: True\n}",
+        "[.5, 2e, +.5, -Infinity]",
+        "{items:[1,2,], name:'Ada',}",
+        "{name:'Ada', nested:{items:[1,2,3}",
+        "{\"a\":1}\n{\"b\":2}\n[3,4]",
+    ];
+
+    for input in cases {
+        let expected = jsonrepair(input).unwrap();
+        for chunk_size in [1, 2, 3, 5, 8, 13] {
+            let mut reader = ChunkedReader::new(input.as_bytes(), chunk_size);
+            let mut output = Vec::new();
+
+            jsonrepair_reader_to_writer(&mut reader, &mut output).unwrap();
+
+            assert_eq!(
+                String::from_utf8(output).unwrap(),
+                expected,
+                "input {input:?} with chunk size {chunk_size}",
+            );
+        }
+    }
+}
+
+#[test]
 fn preserves_repair_errors_without_partial_output() {
     let mut input = Cursor::new(br#""\u00""#);
     let mut output = Vec::new();


### PR DESCRIPTION
## Summary

- add `RepairOptions` plus strict-mode `*_with_options` APIs across string, writer, reader, and serde helpers
- document strict/default repair policy and future policy toggles
- extend streaming design notes with parser states, rollback windows, and commit policy
- add chunk-boundary tests for strings, comments, numbers, trailing commas, missing delimiters, and NDJSON

Closes #31.
Closes #32.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-targets`
- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTFLAGS="-Dwarnings" cargo check --all-targets`
- `git diff --check`