### PR TITLE
Reject plus-prefixed bare dot numbers

### DIFF
--- a/src/parser/number.rs
+++ b/src/parser/number.rs
@@ -50,6 +50,11 @@ impl JsonRepairer {
                 has_leading_dot = true;
                 self.pos += 1;
 
+                if self.pos >= len || !chars::is_digit(self.chars[self.pos]) {
+                    self.pos = start;
+                    return Ok(false);
+                }
+
                 while self.pos < len && chars::is_digit(self.chars[self.pos]) {
                     self.pos += 1;
                 }

--- a/tests/number_regression_tests.rs
+++ b/tests/number_regression_tests.rs
@@ -1,0 +1,30 @@
+use jsonrepair_rs::jsonrepair;
+
+fn assert_repaired_json(input: &str) {
+    let repaired = jsonrepair(input).unwrap_or_else(|err| {
+        panic!("repair failed for {input:?}: {err}");
+    });
+
+    serde_json::from_str::<serde_json::Value>(&repaired).unwrap_or_else(|err| {
+        panic!("invalid repaired JSON for {input:?}: {repaired:?}: {err}");
+    });
+}
+
+#[test]
+fn plus_prefixed_bare_dot_is_rejected() {
+    assert!(
+        jsonrepair("+.").is_err(),
+        "bare plus-prefixed dot must not repair to invalid JSON"
+    );
+    assert!(
+        jsonrepair("[+.]").is_err(),
+        "bare plus-prefixed dot in arrays must not repair to invalid JSON"
+    );
+}
+
+#[test]
+fn plus_prefixed_leading_dot_numbers_remain_parseable() {
+    assert_repaired_json("+.5");
+    assert_repaired_json("[+.5]");
+    assert_repaired_json("{value:+.5}");
+}


### PR DESCRIPTION
## Summary
- reject leading-dot numbers when the dot is not followed by a digit
- add number regression tests for `+.` / `[+.]` rejection and parseable `+.5` repairs

## Tests
- `cargo check`
- `cargo test --test number_regression_tests`
- `cargo test`
- `cargo test --features serde`
- `out=$(printf '+.' | cargo run --quiet --bin jsonrepair 2>/dev/null); cmd_status=$?; test $cmd_status -ne 0; test -z "$out"`
- `printf '+.5' | cargo run --quiet --bin jsonrepair | python3 -c 'import json, sys; data = sys.stdin.read(); assert data == "0.5", repr(data); json.loads(data)'`

Closes #41