### PR TITLE
Prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.2.1 - 2026-06-01
+
+Release notes suitable for a GitHub Release are also available at
+[`docs/releases/v0.2.1.md`](docs/releases/v0.2.1.md).
+
+### Fixed
+
+- Rejected plus-prefixed bare-dot numbers such as `+.` instead of repairing
+  them into invalid JSON.
+
+### Added
+
+- Added a public feature parity matrix comparing `jsonrepair-rs` with the
+  JavaScript `jsonrepair` and Python `json-repair` packages.
+- Added an LLM fallback parsing guide with copy-paste examples for
+  `serde_json::Value`, typed `serde` deserialization, and strict mode.
+
+### Changed
+
+- Refreshed the README introduction to make the Rust-native positioning,
+  trust signals, and known limits clear from the first screen.
+
+### Compatibility
+
+- This release is source-compatible with `0.2.0`.
+- The reader-to-writer API remains streaming-oriented at the IO boundary, but
+  still buffers internally instead of performing constant-memory repair.
+- Schema-guided repair is still not implemented; validate repaired data in the
+  application layer.
+
 ## 0.2.0 - 2026-04-27
 
 Release notes suitable for a GitHub Release are also available at

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "jsonrepair-rs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrepair-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Repair broken JSON — fix quotes, commas, comments, trailing content, and 30+ other issues"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Or add it manually:
 
 ```toml
 [dependencies]
-jsonrepair-rs = "0.2.0"
+jsonrepair-rs = "0.2.1"
 ```
 
 Minimum supported Rust version: 1.70.
@@ -234,8 +234,8 @@ them outside this crate.
 - The crate preserves much of the original whitespace where possible.
 - It returns a repaired JSON string, not a `serde_json::Value`.
 - The `jsonrepair_reader_to_writer` API supports reader-to-writer workflows,
-  but `0.2.0` still buffers internally instead of performing constant-memory
-  repair.
+  but the current parser still buffers internally instead of performing
+  constant-memory repair.
 - It is designed for practical repair, not for accepting arbitrary unsafe input
   as if it were trustworthy. Validate the repaired data according to your
   application's schema before using it.
@@ -382,7 +382,7 @@ instead of reporting a false regression.
 
 ## Release Status
 
-The latest crate published on crates.io is `0.2.0`.
+The latest crate published on crates.io is `0.2.1`.
 
 To publish a new release, first bump the version in `Cargo.toml` and update any
 version references in this README. Then follow

--- a/docs/llm-fallback-parsing.md
+++ b/docs/llm-fallback-parsing.md
@@ -62,7 +62,7 @@ helpers:
 
 ```toml
 [dependencies]
-jsonrepair-rs = { version = "0.2.0", features = ["serde"] }
+jsonrepair-rs = { version = "0.2.1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ```

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -1,0 +1,47 @@
+# jsonrepair-rs 0.2.1
+
+This patch release publishes the latest correctness fix and adoption-focused
+documentation updates to crates.io.
+
+## Highlights
+
+- Rejects plus-prefixed bare-dot numbers such as `+.` instead of producing
+  invalid JSON.
+- Adds `FEATURE_PARITY.md`, a public comparison with the JavaScript
+  `jsonrepair` and Python `json-repair` packages.
+- Refreshes the README introduction with clearer Rust-native positioning,
+  trust signals, and known limits.
+- Adds `docs/llm-fallback-parsing.md`, a production-style guide for using
+  `jsonrepair-rs` as an explicit fallback after strict `serde_json` parsing
+  fails.
+
+## Compatibility Notes
+
+Existing `0.2.0` callers should not need code changes.
+
+This release does not change the public API. The reader-to-writer helpers are
+still IO convenience APIs that buffer internally, not true constant-memory
+streaming repair. Schema-guided repair remains out of scope for this release;
+callers should continue validating repaired data against their own schema or
+typed structures.
+
+## Included PRs
+
+- #42: Reject plus-prefixed bare dot numbers.
+- #46: Add feature parity matrix.
+- #47: Refresh README positioning.
+- #48: Add LLM fallback parsing guide.
+
+## Validation
+
+Run before publishing:
+
+```bash
+RUSTFLAGS="-Dwarnings" cargo check --all-targets
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-targets --all-features
+cargo doc --no-deps
+cargo package --allow-dirty
+cargo publish --dry-run --allow-dirty
+```


### PR DESCRIPTION
## Summary
- bump crate version and lockfile to `0.2.1`
- add `CHANGELOG.md` and `docs/releases/v0.2.1.md` notes for #42, #46, #47, and #48
- update README and fallback-guide version references to `0.2.1`

## Release validation
- `RUSTFLAGS="-Dwarnings" cargo check --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `cargo doc --no-deps`
- `cargo package --allow-dirty`
- `cargo publish --dry-run --allow-dirty`
- `cargo package --list --allow-dirty | rg "FEATURE_PARITY|llm-fallback|v0.2.1|README|CHANGELOG"`

Closes #49
