### PR TITLE
Trim published crate package size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Release notes suitable for a GitHub Release are also available at
 
 - Refreshed the README introduction to make the Rust-native positioning,
   trust signals, and known limits clear from the first screen.
+- Excluded the README card image from the published crate package while keeping
+  it rendered through a repository URL.
 
 ### Compatibility
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["json", "repair", "fix", "parser", "llm"]
 categories = ["parser-implementations", "encoding"]
 readme = "README.md"
 rust-version = "1.70"
+exclude = ["docs/assets/*"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docs.rs](https://docs.rs/jsonrepair-rs/badge.svg)](https://docs.rs/jsonrepair-rs)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-![jsonrepair-rs: Repair malformed JSON into valid JSON](docs/assets/jsonrepair-rs-card.png)
+![jsonrepair-rs: Repair malformed JSON into valid JSON](https://raw.githubusercontent.com/majiayu000/jsonrepair-rs/main/docs/assets/jsonrepair-rs-card.png)
 
 Repair malformed JSON-like text and return valid JSON text.
 

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -14,6 +14,8 @@ documentation updates to crates.io.
 - Adds `docs/llm-fallback-parsing.md`, a production-style guide for using
   `jsonrepair-rs` as an explicit fallback after strict `serde_json` parsing
   fails.
+- Excludes the README card image from the crates.io package while keeping it
+  rendered through a repository URL, reducing package upload size.
 
 ## Compatibility Notes
 


### PR DESCRIPTION
## Summary
- exclude `docs/assets` from the crates.io package
- switch the README card image to a repository raw URL so it still renders outside the packaged crate
- note the package-size reduction in the v0.2.1 changelog and release notes

## Validation
- `cargo package --list --allow-dirty | rg "docs/assets|jsonrepair-rs-card|README|Cargo.toml|v0.2.1" || true`
- `cargo package --allow-dirty` packaged 60 files, 250.1KiB / 62.9KiB compressed
- `RUSTFLAGS="-Dwarnings" cargo check --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `cargo doc --no-deps`
- `cargo publish --dry-run --allow-dirty`

Closes #51
