### PR TITLE
Keep README accurate while publish is pending

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Or add it manually:
 
 ```toml
 [dependencies]
-jsonrepair-rs = "0.2.1"
+jsonrepair-rs = "0.2.0"
 ```
 
 Minimum supported Rust version: 1.70.
@@ -382,7 +382,8 @@ instead of reporting a false regression.
 
 ## Release Status
 
-The latest crate published on crates.io is `0.2.1`.
+The latest crate published on crates.io is `0.2.0`. The `0.2.1` release is
+prepared on `main` and waiting on crates.io token refresh before publishing.
 
 To publish a new release, first bump the version in `Cargo.toml` and update any
 version references in this README. Then follow

--- a/docs/llm-fallback-parsing.md
+++ b/docs/llm-fallback-parsing.md
@@ -62,7 +62,7 @@ helpers:
 
 ```toml
 [dependencies]
-jsonrepair-rs = { version = "0.2.1", features = ["serde"] }
+jsonrepair-rs = { version = "0.2.0", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ```


### PR DESCRIPTION
## Summary
- keep install snippets on the currently published crates.io version while `0.2.1` is pending publish
- clarify that `0.2.1` is prepared on `main` but blocked on crates.io token refresh

## Tests
- `cargo test --all-targets --all-features`

Closes #54
